### PR TITLE
Clarifying sign up process in the invite email

### DIFF
--- a/outbound_email/src/inviteEmailHandler.js
+++ b/outbound_email/src/inviteEmailHandler.js
@@ -64,7 +64,7 @@ CodeStream's cloud-based service and IDE plugins help dev teams discuss, review,
 <br/>
 1. Install CodeStream for ${allLinks}.<br/>
 <br/>
-2. Sign up using <b>${this.user.email}</b>.<br/>
+2. Inside your IDE open CodeStream and sign up using <b>${this.user.email}</b>.<br/>
 <br/>
 Team CodeStream<br/>
 </html>


### PR DESCRIPTION
I invited my friend to try out CodeStream with me and they didn't understand from the invitation email that you had to sign up in your IDE.  I added a line to make the instructions more specific and clear about where to sign up.